### PR TITLE
fix: update animation builder params

### DIFF
--- a/lib/src/hold_to_confirm_button.dart
+++ b/lib/src/hold_to_confirm_button.dart
@@ -142,16 +142,19 @@ class _HoldToConfirmButtonState extends State<HoldToConfirmButton>
                   ],
                 ).createShader(rect);
               },
-              child: Container(
-                padding: widget.contentPadding,
-                decoration: BoxDecoration(
-                  color: widget.backgroundColor,
-                  borderRadius: widget.borderRadius,
-                ),
-                child: widget.child,
-              ),
+              child: child,
             );
           },
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: widget.backgroundColor,
+              borderRadius: widget.borderRadius,
+            ),
+            child: Padding(
+              padding: widget.contentPadding,
+              child: widget.child,
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This PRs adds a minor optimization for AnimationBuilder by:
- using `child` to cache internal child in AnimationBuilder `builder` callback
- avoid using container (big wrapper) 